### PR TITLE
fix: Replace entity.kill() with entity.discard()

### DIFF
--- a/src/main/java/com/vanillapings/features/ping/PingedEntity.java
+++ b/src/main/java/com/vanillapings/features/ping/PingedEntity.java
@@ -73,7 +73,7 @@ public class PingedEntity {
         }
 
         if(kill)
-            entity.kill((ServerWorld) entity.getEntityWorld());
+            entity.discard();
     }
 
     private boolean shouldInterfereWithGlowing() {


### PR DESCRIPTION
Using entity.kill() emits game events that can trigger unintended behavior (such as activating sculk sensors or the Warden). This change replaces it with entity.discard(), which removes the entity silently without firing those events.